### PR TITLE
Add :connected? key to stream returned by connect.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,12 @@
-(defproject haslett "0.1.2"
+(defproject haslett "0.1.3-alpha1"
   :description "A lightweight WebSocket library for ClojureScript"
   :url "https://github.com/weavejester/haslett"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/clojurescript "1.9.946"]
-                 [org.clojure/core.async "0.3.465"]
-                 [com.cognitect/transit-cljs "0.8.243"]]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/clojurescript "1.10.520"]
+                 [org.clojure/core.async "0.4.490"]
+                 [com.cognitect/transit-cljs "0.8.256"]]
   :plugins [[lein-cljsbuild "1.1.6"]]
   :aliases {"test" ["run" "-m" "haslett.test-runner"]}
   :profiles

--- a/test/haslett/client_test.cljs
+++ b/test/haslett/client_test.cljs
@@ -10,12 +10,14 @@
     (go (let [stream (<! (ws/connect "ws://localhost:3200"))]
           (>! (:sink stream) "Hello World")
           (is (= (<! (:source stream)) "Hello World"))
+          (is (:connected? stream))
           (ws/close stream)
-          (done))))) 
+          (done)))))
 
 (deftest test-transit
   (async done
     (go (let [stream (<! (ws/connect "ws://localhost:3200" {:format fmt/transit}))]
+          (is (:connected? stream))
           (>! (:sink stream) {:hello "World"})
           (is (= (<! (:source stream)) {:hello "World"}))
           (ws/close stream)
@@ -24,6 +26,7 @@
 (deftest test-edn
   (async done
     (go (let [stream (<! (ws/connect "ws://localhost:3200" {:format fmt/edn}))]
+          (is (:connected? stream))
           (>! (:sink stream) {:hello "World"})
           (is (= (<! (:source stream)) {:hello "World"}))
           (ws/close stream)
@@ -32,6 +35,7 @@
 (deftest test-json
   (async done
     (go (let [stream (<! (ws/connect "ws://localhost:3200" {:format fmt/json}))]
+          (is (:connected? stream))
           (>! (:sink stream) {:hello "World"})
           (is (= (<! (:source stream)) {"hello" "World"}))
           (ws/close stream)
@@ -44,9 +48,10 @@
           (is (= (<! (:close-status stream)) {:code 1005, :reason ""}))
           (done)))))
 
-(deftest test-connectin-fail
+(deftest test-connection-fail
   (async done
     (go (let [stream (<! (ws/connect "ws://localhost:3201"))]
+          (is (not (:connected? stream)))
           (is (= (<! (:source stream)) nil))
           (is (= (<! (:close-status stream)) {:code 1006, :reason ""}))
           (done)))))


### PR DESCRIPTION
Hi James.

This change allows users to discern between connection failure and close of an open socket without having to poll reading close-status (I'm not actually sure about whether such polling is guaranteed to work anyway, since this is all async).

Also: updated dependences, and fixed a typo in tests.