### PR TITLE
Add connected? fn

### DIFF
--- a/src/haslett/client.cljs
+++ b/src/haslett/client.cljs
@@ -35,10 +35,10 @@
      (set! (.-onopen socket)     (fn [_] (a/put! return stream)))
      (set! (.-onmessage socket)  (fn [e] (a/put! source (fmt/read format (.-data e)))))
      (set! (.-onclose socket)    (fn [e]
-                                   (a/put! return stream)
                                    (a/put! status {:reason (.-reason e), :code (.-code e)})
                                    (a/close! source)
-                                   (a/close! sink)))
+                                   (a/close! sink)
+                                   (a/put! return stream)))
      (go-loop []
        (when-let [msg (<! sink)]
          (.send socket (fmt/write format msg))
@@ -50,3 +50,8 @@
   [stream]
   (.close (:socket stream))
   (:close-status stream))
+
+(defn connected?
+  "Return true if the stream is currently connected."
+  [{:keys [close-status]}]
+  (nil? (a/poll! close-status)))

--- a/test/haslett/client_test.cljs
+++ b/test/haslett/client_test.cljs
@@ -8,6 +8,7 @@
 (deftest test-defaults
   (async done
     (go (let [stream (<! (ws/connect "ws://localhost:3200"))]
+          (is (ws/connected? stream))
           (>! (:sink stream) "Hello World")
           (is (= (<! (:source stream)) "Hello World"))
           (ws/close stream)
@@ -47,6 +48,7 @@
 (deftest test-connectin-fail
   (async done
     (go (let [stream (<! (ws/connect "ws://localhost:3201"))]
+          (is (not (ws/connected? stream)))
           (is (= (<! (:source stream)) nil))
           (is (= (<! (:close-status stream)) {:code 1006, :reason ""}))
           (done)))))


### PR DESCRIPTION
Make it easier for clients to tell whether a stream is currently connected.

Also, on close, set state of channels and promises in stream before publishing it.