### PR TITLE
Fix use of invalid variable name (close-status -> status)

### DIFF
--- a/src/haslett/client.cljs
+++ b/src/haslett/client.cljs
@@ -48,7 +48,7 @@
          (recur))
 
        (a/close! source)
-       (a/put! close-status {:reason "Closed by creator", :code 0})
+       (a/put! status {:reason "Closed by creator", :code 0})
        (.close (:socket stream)))
      return)))
 


### PR DESCRIPTION
Somehow an invalid variable name sneaked into my last PR. I have no idea how my tests or the CI tests passed, but I had referred to `close-status` rather than `status`. Only just noticed when I updated to the release you just created.

Sorry, and apologies for the hassle.